### PR TITLE
Fix `external/repo#123 (files)` links

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ function shortenURL(href, currentUrl = 'https://github.com') {
 	}
 
 	if (pull && pullPage) {
-		return `#${pull} (${pullPage})`;
+		return `${repoUrl}#${pull} (${pullPage})`;
 	}
 
 	if (compare) {

--- a/test.js
+++ b/test.js
@@ -267,6 +267,10 @@ test('GitHub.com URLs', urlMatcherMacro, new Map([
 		'#123 (files)'
 	],
 	[
+		'https://github.com/nodejs/node/pull/123/files',
+		'nodejs/node#123 (files)'
+	],
+	[
 		'https://github.com/fregante/shorten-repo-url/pull/123/commits',
 		'#123 (commits)'
 	],


### PR DESCRIPTION
For example 

https://github.com/sindresorhus/refined-github/pull/3149/files

would be shortened to

`#3149 (files)` on this repo instead of `sindresorhus/refined-github#3149 (files)`