### PR TITLE
Ignore links that contain tags/images in `applyToLink`

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ function applyToLink(a, currentUrl) {
 	// Shorten only if the link name hasn't been customized.
 	// .href automatically adds a / to naked origins so that needs to be tested too
 	// `trim` makes it compatible with this feature: https://github.com/sindresorhus/refined-github/pull/3085
-	if (a.href === a.textContent.trim() || a.href === `${a.textContent}/`) {
+	if ((a.href === a.textContent.trim() || a.href === `${a.textContent}/`) && !a.firstElementChild) {
 		const shortened = shortenURL(a.href, currentUrl);
 		a.innerHTML = shortened;
 		return true;


### PR DESCRIPTION
Issue https://github.com/sindresorhus/refined-github/issues/4505 shorten-links feature hides markdown images which are part of a link